### PR TITLE
ゲーム開始時のターン設定ロジックを修正し、ダイヤの3を持つプレイヤーから自由にカードを出せるように変更

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,1 @@
+language: "ja-JP"

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ NUM_EPISODES = 10  # シミュレーションするゲームの回数
 
 def main():
     # エージェントのクラスを指定
-    agent_classes = [StraightAgent, RandomAgent, RuleBasedAgent, StraightAgent]
+    agent_classes = [RandomAgent, RandomAgent, RuleBasedAgent, StraightAgent]
     env = DaifugoSimpleEnv(num_players=4, agent_classes=agent_classes)  # プレイヤー数4人で環境を初期化
 
     # 順位の集計用: {順位（1〜4）: {player_id: カウント数}}


### PR DESCRIPTION
このプルリクエストでは、game/game.py のゲームロジックを大富豪のルールにより適合させるための調整を行いました。特に、ゲームの開始方法や、場がリセットされた後のターン処理に関する修正が中心です。また、main.py におけるデフォルトのエージェント構成も更新しています。
主な変更点は以下の通りです：

🎮 ゲーム開始ルールの調整
ゲームは「ダイヤの3（♢3）」を持つプレイヤーから始まりますが、そのカードを必ず出す必要はなくなりました。
代わりに、場は空の状態で始まり、そのプレイヤーは任意のカードを出せます。

🔁 ターンと場のリセット処理の改善
場がリセットされた後（8切りやジョーカーなどの特殊カードによる場合）、必ず「最後にカードを出したプレイヤー」にターンが戻るようになりました。
これにより、ターン順が正しく保たれ、同じプレイヤーが連続してプレイするケースにも対応します。
特殊技（8切り、ジョーカー）による場のリセット時に、last_player を正しく設定するように統一されました。
これにより、次に誰がプレイすべきかを確実に追跡できます。

✅ プレイのバリデーション改善
通常のターン（場にカードがある場合）では、出すカードの枚数が場のカードの枚数と一致する場合のみ、有効なプレイとして扱われます。
これにより、無効な出し方（例：1枚出しに対して2枚を出すなど）が防止されます。

🧠 エージェント構成の更新
main.py のデフォルトエージェント構成を変更しました：
これまでの StraightAgent ×2 に代えて、RandomAgent ×2、RuleBasedAgent ×1、StraightAgent ×1 の構成になりました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ゲーム開始時、最初のプレイヤーは空の場で自由にプレイできるようになり、初動の柔軟性が向上しました。

* **Bug Fixes**
  * 8カットやジョーカーによる場のリセット後のターン継続処理を改善し、正しいプレイヤー順でスムーズなゲーム進行を実現しました。
  * 場のリセットとターンの更新タイミングを見直し、特殊なプレイ時の挙動を安定化しました。

* **Chores**
  * ゲームに参加するエージェントの組み合わせを更新し、最初の2プレイヤーをランダムエージェントに変更しました。

* **Chores**
  * 日本語設定を指定する新しい構成ファイルを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->