### PR TITLE
ジョーカーの流しルールを修正し、2のペアとジョーカーの特殊判定を追加。エージェントのクラスを修正。

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -188,8 +188,8 @@ class Game:
             self.last_player = self.turn
             self._reset_field()
             return True, (self.get_state(self.turn), False, True)
-        # ジョーカー流し
-        if any(card.is_joker for card in card_objs):
+        # ジョーカー流し（ジョーカー1枚出しのみ）
+        if len(card_objs) == 1 and card_objs[0].is_joker:
             self.last_player = self.turn
             self._reset_field()
             return True, (self.get_state(self.turn), False, True)

--- a/game/rules.py
+++ b/game/rules.py
@@ -69,6 +69,17 @@ class RuleChecker:
         if play_count != field_count:
             return False
 
+        # --- 2のペア＋ジョーカーの特殊判定 ---
+        # 場が2,ジョーカー(2)のペアなら、何も上書きできない
+        if (
+            play_count == 2 and field_count == 2
+            and self.is_same_rank_or_joker(current_field)
+            and any(card.is_joker for card in current_field)
+            and all((card.rank == 2 or card.is_joker) for card in current_field)
+        ):
+            # 2,ジョーカー(2)のペアが場に出ている場合は、どんなペアも不可
+            return False
+
         # 強さ比較
         if self.revolution:
             field_strength = min(field_strengths) if field_strengths else -1

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ NUM_EPISODES = 10  # シミュレーションするゲームの回数
 
 def main():
     # エージェントのクラスを指定
-    agent_classes = [RandomAgent, RandomAgent, RuleBasedAgent, StraightAgent]
+    agent_classes = [RandomAgent, RandomAgent, RuleBasedAgent, RuleBasedAgent]
     env = DaifugoSimpleEnv(num_players=4, agent_classes=agent_classes)  # プレイヤー数4人で環境を初期化
 
     # 各プレイヤーの累計報酬を集計


### PR DESCRIPTION
プレイヤー3のエージェントをルールベースに変更
ジョーカー流しは1枚出しの時のみ許可

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - ジョーカー流しの条件を「1枚出しのジョーカー」に限定し、ルール解釈に合わせて動作を整理。
  - 2枚場が2/ジョーカーの同種扱いとなるケースでは、上書き手を無効として扱うように調整。
- 雑務
  - デフォルトの対戦エージェント構成を更新（ランダム×2、ルールベース×2）し、実行時の組み合わせを変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->