### PR TITLE
Rl agent game logic

### DIFF
--- a/agents/config.py
+++ b/agents/config.py
@@ -72,6 +72,12 @@ ALPHA_ZERO_CONFIG = {
     # ---------------------------
     "use_shared_replay": True,       # 全エージェントで単一の共有リプレイバッファを使用
     "replay_recent_sample_ratio": 0.0,  # >0 なら直近一定割合を優先サンプリング (未実装placeholder)
+    # ---------------------------
+    # ハードウェア / デバイス
+    # ---------------------------
+    # 'auto' -> torch.cuda.is_available() なら 'cuda'、それ以外は 'cpu'
+    # 明示的に 'cpu' / 'cuda' / 'cuda:0' などを指定することも可能
+    "device": "auto",
 }
 
 __all__ = ["ALPHA_ZERO_CONFIG"]

--- a/agents/models.py
+++ b/agents/models.py
@@ -17,19 +17,16 @@
   logits, value = model.forward(state_dict)
   -> logits: Tensor(shape=[max_policy_size])
      value : Tensor(shape=[1])  (tanh で -1~1)
-
-PyTorch 依存: torch が未インストールの場合は ImportError を送出する。
 """
 from __future__ import annotations
 
 from typing import Dict, Any, Optional, List
 
-try:
-    import torch
-    import torch.nn as nn
-    import torch.nn.functional as F
-except ImportError as e:  # pragma: no cover
-    raise ImportError("PyTorch がインストールされていません。pip install torch で導入してください.") from e
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
 
 
 class PolicyValueNet(nn.Module):
@@ -42,6 +39,7 @@ class PolicyValueNet(nn.Module):
         self.max_policy_size = max_policy_size
         self.num_players = num_players
         self.device = torch.device(device) if device else torch.device("cpu")
+        
 
         # 入力特徴量: hand_size(1) + field_size(1) + turn_onehot(num_players)
         input_dim = 2 + num_players

--- a/game/game.py
+++ b/game/game.py
@@ -21,6 +21,12 @@ class Game:
         self.last_player = None # 最後にカードを出したプレイヤー
         self.rankings = []  # 上がった順に記録するリスト
         self._deal_cards()  # カードを配る
+        # 革命デバッグ用フラグ: True の場合 REV_EVENT 行を出力
+        self.debug_revolution_trace = True
+        # ゲーム終了時に革命イベントを自動出力するフラグ
+        self.auto_dump_revolution_events = True
+        # 見出しを一度だけ出すための内部フラグ
+        self._rev_events_header_printed = True
 
     def _all_others_passed(self):
         """
@@ -49,6 +55,7 @@ class Game:
         self.rankings = []
         self._deal_cards()  # 新しい手札を配る
         self.rule_checker.reset_revolution()  # 革命状態もリセット
+        self.rule_checker.clear_revolution_events()  # イベント履歴をクリア
         # 新しい手札が配られた後にカード交換を実施
         if prev_rankings and len(prev_rankings) == self.num_players:
             self.rule_checker.exchange_cards_by_rankings(self.players, prev_rankings)
@@ -157,16 +164,61 @@ class Game:
                 pass
             # ゲーム中の出力を「Player X played: ...」形式に（解決済みの card_objs を使用）
             played_str = ', '.join(str(c) for c in card_objs) if card_objs else ''
-            self.log(f"Player {self.turn} played: {played_str}")
+            # 1) 場に反映
             self._play_cards(player, card_objs)
             self.last_player = self.turn
-            # 特殊ルール処理
-            reset_happened, ret = self._handle_special_rules(card_objs)
-            if reset_happened:
-                return ret
+            # 2) 革命判定のみ先に実行 (出力順制御のため分離)
+            prev_rev = self.rule_checker.revolution
+            rev_triggered = False
+            try:
+                # 四枚同ランク or 5枚以上階段で革命トグル (イベント記録付き)
+                rev_triggered = self.rule_checker.check_revolution(
+                    card_objs,
+                    player_id=self.turn,
+                    turn_count=self.turn_count
+                )
+            except Exception:
+                pass
+            new_rev = self.rule_checker.revolution
+            rev_changed = (prev_rev != new_rev)
+            rev_flag = ' (REV)' if new_rev else ''
+            trig = ' [+REV]' if rev_changed and new_rev else (' [-REV]' if rev_changed and not new_rev else '')
+            # 3) プレイログ (リセット系より先に必ず出す)
+            self.log(f"Player {self.turn} played: {played_str}{rev_flag}{trig}")
+            # 革命発生メッセージ (オプション) - 従来互換
+            if rev_triggered:
+                self.log(f"革命発生! 現在の革命状態: {self.rule_checker.revolution}")
+                if self.debug_revolution_trace:
+                    # 直近イベントのみ取り出し
+                    ev = self.rule_checker.revolution_events[-1] if self.rule_checker.revolution_events else None
+                    if ev:
+                        self.log(
+                            "REV_EVENT "
+                            f"turn={ev['turn']} player={ev['player']} reason={ev['reason']} "
+                            f"old={ev['old_state']} new={ev['new_state']} cards={ev['cards']} meta={ev['meta']}"
+                        )
+            # 4) その他特殊ルール: 階段表示 / 8切り / ジョーカー流し
+            try:
+                # 階段 (表示のみ)
+                if self.rule_checker.is_straight(card_objs):
+                    self.log(f"Player {self.turn} が階段を出しました: {[str(c) for c in card_objs]}")
+            except Exception:
+                pass
+            # 8切り
+            if self.rule_checker.is_8cut(card_objs):
+                self.log(f"8切り発動 by Player {self.turn}!")
+                self.last_player = self.turn
+                self._reset_field()
+                return self.get_state(self.turn), False, True, "eight_cut"
+            # ジョーカー流し
+            if len(card_objs) == 1 and card_objs[0].is_joker:
+                self.last_player = self.turn
+                self._reset_field()
+                return self.get_state(self.turn), False, True, "joker_cut"
         else:
             # ゲーム中の出力を「Player X passed.」形式に
-            self.log(f"Player {self.turn} passed.")
+            rev_flag = ' (REV)' if self.rule_checker.revolution else ''
+            self.log(f"Player {self.turn} passed.{rev_flag}")
             action_cards = None
             self.passed[self.turn] = True
             # 最後に出したプレイヤー以外が全員パス → 場リセット
@@ -245,8 +297,30 @@ class Game:
             last_player = [i for i in range(self.num_players) if i not in self.rankings][0]
             self.rankings.append(last_player)
             self.done = True
+            if self.auto_dump_revolution_events:
+                self.dump_revolution_events()
             return True
         return False
+
+    # --- 革命イベントログ出力ユーティリティ -----------------------
+    def dump_revolution_events(self):
+        """現在のゲームに記録された革命イベントログを整形して出力する。"""
+        events = self.rule_checker.get_revolution_events()
+        if not events:
+            self.log("[REV_EVENTS] (none)")
+            return
+        if not self._rev_events_header_printed:
+            self.log("[REV_EVENTS] turn player reason old->new size cards meta")
+            self._rev_events_header_printed = True
+        for ev in events:
+            self.log(
+                f"[REV_EVENTS] {ev['turn']} P{ev['player']} {ev['reason']} "
+                f"{ev['old_state']}->{ev['new_state']} {ev['size']} {ev['cards']} {ev['meta']}"
+            )
+
+    def print_revolution_events(self):
+        """エイリアスメソッド (dump_revolution_events と同じ)。"""
+        self.dump_revolution_events()
 
     # --- 補助メソッド ---
     def _find_hand_cards(self, player, action_cards):

--- a/game/game.py
+++ b/game/game.py
@@ -26,7 +26,7 @@ class Game:
         # ゲーム終了時に革命イベントを自動出力するフラグ
         self.auto_dump_revolution_events = True
         # 見出しを一度だけ出すための内部フラグ
-        self._rev_events_header_printed = True
+        self._rev_events_header_printed = False
 
     def _all_others_passed(self):
         """

--- a/game/rules.py
+++ b/game/rules.py
@@ -20,6 +20,9 @@ class RuleChecker:
         self.rev_enable_straight = True
         self.rev_straight_min_len = 5
         self.rev_straight_allow_joker = True
+        # 同一手番・同一カード集合での重複トグル防止用（idempotent 保護）
+        # キー: (turn_count, player_id, tuple(sorted(str(c) for c in cards)))
+        self._rev_seen_actions = set()
     
     # === 役分類 / 比較ユーティリティ =====================================
     def classify_combo(self, cards):
@@ -291,6 +294,17 @@ class RuleChecker:
         革命発生条件を判定し、該当すればself.revolutionをTrueにする。
         例: 同じランク4枚以上（ジョーカー含む場合は調整可）、または5枚以上の階段
         """
+        # 同一手番・同一カード集合に対する重複判定（安全側: 情報が無ければスキップ）
+        action_key = None
+        try:
+            if turn_count is not None and player_id is not None and cards is not None:
+                canonical_cards = tuple(sorted(str(c) for c in cards))
+                action_key = (int(turn_count), int(player_id), canonical_cards)
+                if action_key in self._rev_seen_actions:
+                    return False
+        except Exception:
+            # 何らかの理由でキー生成失敗時は保護を無効化して継続
+            action_key = None
         non_jokers = [c for c in cards if not c.is_joker]
         jokers = [c for c in cards if c.is_joker]
         old_state = self.revolution
@@ -339,6 +353,9 @@ class RuleChecker:
                 'meta': meta,
             }
             self.revolution_events.append(event)
+            # このアクションに対するトグルは記録済みとしてマーク（再トグル抑止）
+            if action_key is not None:
+                self._rev_seen_actions.add(action_key)
             return True
         return False
 
@@ -352,6 +369,8 @@ class RuleChecker:
     def clear_revolution_events(self):
         """革命イベント履歴をクリア（新ゲーム開始時など）。"""
         self.revolution_events.clear()
+        # 重複トグル保護のキーもクリア
+        self._rev_seen_actions.clear()
 
     def get_revolution_events(self):
         """革命イベント履歴を返す（参照用）。"""
@@ -380,7 +399,7 @@ class RuleChecker:
         for card in dai_hinmin_give:
             players[dai_hinmin].hand.remove(card)
         players[daifugo].hand.extend(dai_hinmin_give)
-        print(f"大貧民(Player {dai_hinmin})→大富豪(Player {daifugo}): {[str(c) for c in dai_hinmin_give]}")
+        #print(f"大貧民(Player {dai_hinmin})→大富豪(Player {daifugo}): {[str(c) for c in dai_hinmin_give]}")
 
         # --- 大富豪→大貧民（2枚） ---　自分の最も弱いカードを2枚渡す。
         daifugo_hand = sorted(players[daifugo].hand, key=lambda c: c.strength())
@@ -388,18 +407,18 @@ class RuleChecker:
         for card in daifugo_give:
             players[daifugo].hand.remove(card)
         players[dai_hinmin].hand.extend(daifugo_give)
-        print(f"大富豪(Player {daifugo})→大貧民(Player {dai_hinmin}): {[str(c) for c in daifugo_give]}")
+        #print(f"大富豪(Player {daifugo})→大貧民(Player {dai_hinmin}): {[str(c) for c in daifugo_give]}")
 
         # --- 貧民→富豪（1枚） ---　自分の最も強いカードを1枚渡す。
         hinmin_hand = sorted(players[hinmin].hand, key=lambda c: c.strength(), reverse=True)
         hinmin_give = hinmin_hand[0]
         players[hinmin].hand.remove(hinmin_give)
         players[fugo].hand.append(hinmin_give)
-        print(f"貧民(Player {hinmin})→富豪(Player {fugo}): {hinmin_give}")
+        #print(f"貧民(Player {hinmin})→富豪(Player {fugo}): {hinmin_give}")
 
         # --- 富豪→貧民（1枚） ---　自分の最も弱いカードを1枚渡す。
         fugo_hand = sorted(players[fugo].hand, key=lambda c: c.strength())
         fugo_give = fugo_hand[0]
         players[fugo].hand.remove(fugo_give)
         players[hinmin].hand.append(fugo_give)
-        print(f"富豪(Player {fugo})→貧民(Player {hinmin}): {fugo_give}")
+        #print(f"富豪(Player {fugo})→貧民(Player {hinmin}): {fugo_give}")

--- a/game/rules.py
+++ b/game/rules.py
@@ -7,7 +7,20 @@ class RuleChecker:
         # を要求する。これにより 9-10-J の後に J-Q-K や 10-J-Q は不可、最初に出せるのは Q-K-A。
         # デフォルト有効。従来挙動に戻したい場合 False に設定。
         self.strict_straight_progression = True
-
+        # 革命イベントログ: トグル発生時のみ追加
+        # 例: {'turn': 5, 'player': 2, 'reason': 'four_kind', 'cards': [...], 'old_state': False,
+        #       'new_state': True, 'size': 4, 'meta': {'straight_len': None, 'rank': 7, 'jokers':1}}
+        self.revolution_events = []
+        # 革命発生条件の閾値設定（デフォルトは従来寄りの緩め）
+        # - 4枚同ランク（ジョーカー混在可、4枚ちょうどでなく4枚以上）
+        # - 階段は5枚以上（ジョーカー混在可）
+        self.rev_enable_four_kind = True
+        self.rev_four_kind_allow_joker = True
+        self.rev_four_kind_exact = False
+        self.rev_enable_straight = True
+        self.rev_straight_min_len = 5
+        self.rev_straight_allow_joker = True
+    
     # === 役分類 / 比較ユーティリティ =====================================
     def classify_combo(self, cards):
         """カード集合を役情報へ分類。無効なら None。
@@ -30,6 +43,10 @@ class RuleChecker:
 
         # Joker単体
         if n == 1 and jokers:
+            # 単体ジョーカーは代用情報を強制リセットして素の表示に統一
+            jk = jokers[0]
+            jk.joker_as_rank = None
+            jk.joker_as_suit = None
             return {
                 'type': 'joker_single',
                 'size': 1,
@@ -269,22 +286,59 @@ class RuleChecker:
             joker.joker_as_suit = None
         return []
 
-    def check_revolution(self, cards):
+    def check_revolution(self, cards, player_id=None, turn_count=None):
         """
         革命発生条件を判定し、該当すればself.revolutionをTrueにする。
         例: 同じランク4枚以上（ジョーカー含む場合は調整可）、または5枚以上の階段
         """
         non_jokers = [c for c in cards if not c.is_joker]
-        # 4枚以上、かつ全て同じランク（ジョーカーは無視）
-        if len(cards) >= 4:
-            if len(non_jokers) > 0:
-                rank = non_jokers[0].rank
-                if all(c.rank == rank or c.is_joker for c in cards):
-                    self.revolution = not self.revolution  # 革命状態をトグル
-                    return True
-        # 5枚以上の階段
-        if len(cards) >= 5 and self.is_straight(cards):
-            self.revolution = not self.revolution
+        jokers = [c for c in cards if c.is_joker]
+        old_state = self.revolution
+        toggled = False
+        reason = None
+        meta = {
+            'straight_len': None,
+            'rank': None,
+            'jokers': len(jokers),
+        }
+        # 4枚(以上)同ランク条件
+        if self.rev_enable_four_kind and len(non_jokers) > 0:
+            rank = non_jokers[0].rank
+            same_rank_with_jokers = all(c.rank == rank or c.is_joker for c in cards)
+            size_ok = (
+                (len(cards) == 4 if self.rev_four_kind_exact else len(cards) >= 4)
+            )
+            jokers_used = len(jokers) > 0
+            pure = same_rank_with_jokers and not jokers_used
+            cond_joker = self.rev_four_kind_allow_joker or not jokers_used
+            if not toggled and size_ok and same_rank_with_jokers and cond_joker:
+                self.revolution = not self.revolution
+                toggled = True
+                reason = 'four_kind'
+                meta['rank'] = rank
+                meta['pure'] = pure
+        # 階段条件
+        if (self.rev_enable_straight and not toggled and len(cards) >= self.rev_straight_min_len):
+            if self.is_straight(cards):
+                jokers_used = len(jokers) > 0
+                if self.rev_straight_allow_joker or not jokers_used:
+                    self.revolution = not self.revolution
+                    toggled = True
+                    reason = 'long_straight'
+                    meta['straight_len'] = len(cards)
+                    meta['used_joker'] = jokers_used
+        if toggled:
+            event = {
+                'turn': turn_count,
+                'player': player_id,
+                'reason': reason,
+                'cards': [str(c) for c in cards],
+                'old_state': old_state,
+                'new_state': self.revolution,
+                'size': len(cards),
+                'meta': meta,
+            }
+            self.revolution_events.append(event)
             return True
         return False
 
@@ -293,7 +347,17 @@ class RuleChecker:
         革命状態をリセット（場流し時など）
         """
         self.revolution = False
+        # 場流しなどで状態をリセットするが、イベント履歴は残す（完全リセットしたいときは clear_revolution_events を呼ぶ）
 
+    def clear_revolution_events(self):
+        """革命イベント履歴をクリア（新ゲーム開始時など）。"""
+        self.revolution_events.clear()
+
+    def get_revolution_events(self):
+        """革命イベント履歴を返す（参照用）。"""
+        return list(self.revolution_events)
+
+   
     def exchange_cards_by_rankings(self, players, rankings):
         """
         大富豪ルールの順位に応じたカード交換を行う。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+# Core scientific stack
+numpy==1.26.4
+joblib==1.4.2
+
+# Deep learning (used by agents.models / drl_agent)
+torch==2.3.1
+
+# Logging / visualization (optional but referenced in utils.logger)
+# If you don't need TensorBoard, you can remove this
+tensorboard==2.16.2
+
+# TensorBoard compatibility (avoid MessageToJson keyword error)
+protobuf==4.25.3

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -79,11 +79,21 @@ class Trainer:
     # 準備
     # -----------------------------------------------------
     def setup(self):
-        # モデル生成
+        # デバイス決定とモデル生成
+        device_cfg = self.config.get("device", "auto")
+        if device_cfg == "auto":
+            try:
+                import torch  # lazy import to check availability
+                resolved_device = "cuda" if torch.cuda.is_available() else "cpu"
+            except Exception:
+                resolved_device = "cpu"
+        else:
+            resolved_device = device_cfg
         self.model = PolicyValueNet(
             max_policy_size=self.config["max_policy_size"],
             hidden_size=self.config["hidden_size"],
             num_players=self.config["num_players"],
+            device=resolved_device,
         )
         # ロガー生成
         self.logger = TrainingLogger(
@@ -187,6 +197,8 @@ class Trainer:
     # -----------------------------------------------------
     def self_play(self, num_episodes: int = 1):
         for ep in range(num_episodes):
+            # ゲーム開始時にエポック（エピソード）進行を表示
+            print(f"[EPOCH] {ep+1}/{num_episodes}")
             # ウォームアップ期間中は対戦相手をランダム/ルールベースに
             if ep < self.warmup_episodes:
                 self._apply_warmup_opponents()
@@ -304,6 +316,9 @@ class Trainer:
     def train_updates(self, num_updates: int = 1):
         for i in range(num_updates):
             loss_info = self.agents[0].train_step(batch_size=self.config.get("batch_size", 256))
+            # ログ用にエポック情報を付与（存在する辞書に無害に追加）
+            if isinstance(loss_info, dict):
+                loss_info.setdefault("total_epochs", num_updates)
             # サンプル不足/偏り警告
             if loss_info.get("reason") == "no_data":
                 print("[WARN] train_step skipped: no_data (consider increasing episodes or buffer)")
@@ -317,7 +332,7 @@ class Trainer:
                         if ratio < 0.15:  # しきい値は暫定
                             print(f"[WARN] low data share for learner: {own}/{total} ({ratio:.2%})")
             if (i + 1) % self.config.get("log_interval", 50) == 0:
-                print(f"[TRAIN] update={i+1} loss={loss_info}")
+                print(f"[TRAIN] epoch={i+1}/{num_updates} loss={loss_info}")
             # ロガーへ (train_step 内で既に push されている場合は二重記録を避ける)
             if self.logger and loss_info.get("loss") is not None and not getattr(self.agents[0], '_logged_inside', False):
                 self.logger.log_train(loss_info)
@@ -354,6 +369,7 @@ if __name__ == "__main__":
     parser.add_argument("--log-dir", type=str, default=None, help="ログディレクトリ上書き")
     parser.add_argument("--no-tb", action="store_true", help="TensorBoard を無効化")
     parser.add_argument("--seed", type=int, default=None, help="乱数シード上書き")
+    parser.add_argument("--device", type=str, default=None, help="使用デバイスを指定 (cpu/cuda/cuda:0)。未指定はauto")
     args = parser.parse_args()
 
     cfg = dict(ALPHA_ZERO_CONFIG)
@@ -367,8 +383,10 @@ if __name__ == "__main__":
         cfg["enable_tensorboard"] = False
     if args.seed is not None:
         cfg["seed"] = args.seed
+    if args.device is not None:
+        cfg["device"] = args.device
 
-    print("[CLI] Config overrides:", {k: cfg[k] for k in ["num_simulations","batch_size","log_dir","enable_tensorboard"] if k in cfg})
+    #print("[CLI] Config overrides:", {k: cfg[k] for k in ["num_simulations","batch_size","log_dir","enable_tensorboard","device"] if k in cfg})
     trainer = Trainer(config=cfg)
     trainer.setup()
     trainer.self_play(num_episodes=args.episodes)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -211,4 +211,39 @@ class TrainingLogger:
             if self._tb_disabled_reason is None:
                 print(f"[TrainingLogger] MCTSサンプル書き込み失敗 (disk?) : {e}")
 
+    # ---------------- Free-form text logging ----------------
+    def log_text(self, text: str, filename: str = "events.log", also_print: bool = False):
+        """任意のテキストをログに追記し、可能ならTensorBoardにも出力する。
+
+        - logs/events.log にタイムスタンプ付きで追記
+        - TensorBoard が有効な場合は add_text で記録（step は update_step または episode_idx）
+        - also_print=True の場合は標準出力にも表示
+        """
+        try:
+            ts = time.strftime('%Y-%m-%d %H:%M:%S')
+            line = f"[{ts}] {text}\n"
+            path = os.path.join(self.log_dir, filename)
+            os.makedirs(self.log_dir, exist_ok=True)
+            with open(path, 'a', encoding='utf-8') as f:
+                f.write(line)
+            if also_print:
+                print(line.strip())
+        except Exception:
+            # 例外は握りつぶして学習を止めない
+            pass
+
+        if self.tb:
+            try:
+                step = self.update_step or self.episode_idx or 0
+                self.tb.add_text('misc/text', text, step)
+                try:
+                    self.tb.flush()
+                except Exception:
+                    pass
+            except OSError as e:
+                self._disable_tensorboard(f"OSError:{e}")
+            except Exception:
+                # TensorBoard へのテキスト出力失敗は無視
+                pass
+
 __all__ = ["TrainingLogger"]


### PR DESCRIPTION
This pull request introduces significant improvements to device configuration, revolution event tracking, and logging across the codebase. The most important changes are the addition of flexible device selection for training, a comprehensive revolution event logging system in the game logic, and enhanced logging utilities for experiment tracking. These updates improve usability, reproducibility, and debugging capabilities for both training and gameplay.

**Device configuration and selection:**

* Added a `"device"` configuration option (`"auto"`, `"cpu"`, `"cuda"`, etc.) to `ALPHA_ZERO_CONFIG`, and updated `trainer.py` to resolve and propagate the device setting for model initialization. This allows seamless switching between CPU and GPU environments. [[1]](diffhunk://#diff-6661d3ed30ec5dc95d0d0d877727980d2e803f5c511632ec0537738328e6e9b1R75-R80) [[2]](diffhunk://#diff-0564ece5aadc13d5923043addc422a8058c6d96026493e84652cedc2f1bdca99L82-R96) [[3]](diffhunk://#diff-0564ece5aadc13d5923043addc422a8058c6d96026493e84652cedc2f1bdca99R372) [[4]](diffhunk://#diff-0564ece5aadc13d5923043addc422a8058c6d96026493e84652cedc2f1bdca99R386-R389)
* Updated `PolicyValueNet` initialization to accept a `device` parameter and removed unnecessary PyTorch import error handling, simplifying model setup. [[1]](diffhunk://#diff-483c3228a11e56381cc1f4a0f29da83cc4f8cc5e56c247af3694117d2c72b99aL20-R29) [[2]](diffhunk://#diff-483c3228a11e56381cc1f4a0f29da83cc4f8cc5e56c247af3694117d2c72b99aR43)

**Revolution event tracking and logging:**

* Implemented detailed revolution event logging in `game/rules.py` and `game/game.py`, including event history, duplicate event protection, and utility methods for dumping and printing revolution event logs. Revolution events are now tracked with metadata and can be output at game end or on demand. [[1]](diffhunk://#diff-aca874880fc902813fda91ea72e1c26236a880ffe083fe77616a3f211dcb7e34R24-R29) [[2]](diffhunk://#diff-aca874880fc902813fda91ea72e1c26236a880ffe083fe77616a3f211dcb7e34R58) [[3]](diffhunk://#diff-aca874880fc902813fda91ea72e1c26236a880ffe083fe77616a3f211dcb7e34L160-R221) [[4]](diffhunk://#diff-aca874880fc902813fda91ea72e1c26236a880ffe083fe77616a3f211dcb7e34R300-R324) [[5]](diffhunk://#diff-0727a2394647d7588bcef95c007cafbe5247fe67706812c59d4bf9d21e3a4085R10-R25) [[6]](diffhunk://#diff-0727a2394647d7588bcef95c007cafbe5247fe67706812c59d4bf9d21e3a4085L272-R358) [[7]](diffhunk://#diff-0727a2394647d7588bcef95c007cafbe5247fe67706812c59d4bf9d21e3a4085R367-R378)
* Revolution event handling now includes configurable rules for triggering, with support for custom thresholds and joker handling. [[1]](diffhunk://#diff-0727a2394647d7588bcef95c007cafbe5247fe67706812c59d4bf9d21e3a4085R10-R25) [[2]](diffhunk://#diff-0727a2394647d7588bcef95c007cafbe5247fe67706812c59d4bf9d21e3a4085L272-R358)
* Revolution-related output and messaging in gameplay have been improved for clarity and traceability.

**General logging and experiment tracking:**

* Added a free-form text logging method `log_text` to `TrainingLogger`, supporting both file and TensorBoard output for arbitrary experiment notes and events.
* Training and self-play logging now include epoch/episode information for better progress tracking during experiments. [[1]](diffhunk://#diff-0564ece5aadc13d5923043addc422a8058c6d96026493e84652cedc2f1bdca99R200-R201) [[2]](diffhunk://#diff-0564ece5aadc13d5923043addc422a8058c6d96026493e84652cedc2f1bdca99R319-R321) [[3]](diffhunk://#diff-0564ece5aadc13d5923043addc422a8058c6d96026493e84652cedc2f1bdca99L320-R335)

**Other improvements:**

* Suppressed verbose card exchange print statements in `exchange_cards_by_rankings` to reduce console clutter during training.
* Minor fixes and enhancements to rule handling, including forced reset of joker substitution info in combo classification.

These changes collectively enhance the flexibility, transparency, and maintainability of both the training and game simulation systems.<!-- このプルリクエストの内容を日本語で記載してください。 -->
## 概要

## 変更内容

## 動作確認

## その他
[Copilot is generating a summary...]