### PR TITLE
Rl evaluation elo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,103 @@
 # daihugou_rl
 
-大富豪（大貧民）AI対戦・強化学習用シミュレーション環境
+大富豪（大貧民）AI 対戦 / AlphaZero 風強化学習 + Elo 評価環境。
 
-## 開発支援ツール
+学習 (self-play + MCTS) → チェックポイント保存 → Elo 対戦評価 → 自動グラフ生成 までを一通り回せる最小構成です。
 
-本リポジトリでは、AIコードレビュー・自動ドキュメント生成支援のために CodeRabbit（フリー） を導入しています。
-CodeRabbitはVS Code拡張として利用でき、PRレビューやコード説明、リファクタ提案などをAIがサポートします。
-（詳細: https://coderabbit.ai/ja ）
+## 主要機能
 
-## 開発の進め方
+- 大富豪ルール: 革命 / 階段 / 8切り / ジョーカー流し / 順位に応じた次ゲームのカード交換
+- 強化学習エージェント: AlphaZero 風 MCTS + Policy/Value ネット (MLP)
+- リプレイバッファ（共有モード対応）
+- ロギング: CSV / (任意) TensorBoard
+- Elo レーティング: 対戦結果を多人数ペアワイズに分解して更新
+- 評価自動可視化: 評価完了ごとに勝率・平均順位・レーティング推移 PNG を再生成
 
-本リポジトリでは、機能追加やバグ修正ごとに新しいブランチを作成し、
-「feature/○○」「bugfix/○○」など用途ごとにブランチを切り分けて開発を進めています。
-開発が完了したら、プルリクエスト（PR）を作成し、マージする運用をしています
-
-
-## 概要
-
-このリポジトリは、トランプゲーム「大富豪（大貧民）」のルールに基づいたAI対戦・強化学習用のPython環境です。  
-複数のエージェント（AI）が自動で対戦し、順位やカード交換、階段出し・革命などのルールも実装されています。
-
-## ディレクトリ構成
+## ディレクトリ (抜粋)
 
 ```
-daihugou_rl/
-├── main.py                # メイン実行スクリプト
-├── re_main.py             # 別バージョンのメイン（リファクタ用等）
-├── agents/                # 標準エージェント（AI）群
-│   ├── straight_agent.py
-│   ├── random_agent.py
-│   ├── rule_based_agent.py
-│   └── ＿init＿.py
-├── game/                  # ゲーム本体・ルール・環境
-│   ├── card.py
-│   ├── environment.py
-│   ├── game.py
-│   ├── player.py
-│   ├── rules.py
-│   └── ＿init＿.py
-├── re_agents/             # 別バージョンのエージェント
-│   ├── random_agent.py
-│   └── ＿init＿.py
-├── re_game/               # 別バージョンのゲーム本体
-│   ├── card.py
-│   ├── environment.py
-│   ├── game.py
-│   ├── player.py
-│   ├── rules.py
-│   └── ＿init＿.py
-└── venv/                  # 仮想環境（無視してOK）
+agents/         # 学習/ベースラインエージェント (AlphaZero, Random, RuleBased, etc.)
+game/           # ゲーム進行・環境・ルール
+trainer/        # 学習ループ (self-play + train updates)
+evaluation/     # Elo 評価, 自動プロット (evaluator / run_eval / plot_eval / rating)
+checkpoints/    # 最新モデル保存 (policy_value_latest.pt)
+logs/           # 学習 & 評価ログ
+  └─ elo/      # Elo 関連ファイル (ratings.json, ratings.csv, eval_metrics.csv, figs/*.png)
+requirements.txt
 ```
 
-## 主なファイル・モジュール
+## 学習 (Self-Play + 更新)
 
+少数エピソードで動作確認:
 
-- `main.py`  
-  シミュレーションのエントリーポイント。複数エージェントで自動対戦し、順位集計も行う。
-
-- `game/environment.py`  
-  強化学習・AI対戦用の環境クラス（`DaifugoSimpleEnv`）。エージェントの行動選択や合法手生成、リセット処理など。
-
-- `game/game.py`  
-  ゲーム進行の本体クラス。カード配布、ターン管理、カード交換、順位決定など。
-
-- `game/player.py`  
-  プレイヤー（人間・AI問わず）の状態や手札、行動を管理するクラス。
-
-- `game/rules.py`  
-  ルール判定、階段判定、革命、カード交換ロジック（順位に応じて強い/弱いカードを交換）など。
-
-- `agents/`  
-  さまざまなAIエージェント（例：ランダム、ルールベース、階段優先など）。
-
-## 特徴的なルール実装
-
-- 階段出し、ペア出し、ジョーカー、革命、8切りなど大富豪の主要ルールをサポート
-- ゲーム終了後、前回の順位に応じて新しい手札からカード交換を自動実施
-- エージェントは差し替え可能で、強化学習やAI対戦の実験が容易
-
-## 実行方法
-
-1. 必要なパッケージをインストール（例: numpy）
-2. `main.py` を実行
-
-```bash
-python main.py
+```powershell
+python -m trainer.trainer --episodes 5 --updates 5 --device auto
 ```
 
-## カスタマイズ
+出力:
+- `checkpoints/policy_value_latest.pt` モデル
+- `replay_buffer.joblib` リプレイバッファ
+- `logs/episodes.csv`, `logs/train_updates.csv` など
 
-- エージェントの追加・差し替えは `agents/` フォルダにクラスを追加し、`main.py` の `agent_classes` を編集してください。
-- ルールやカード交換ロジックの調整は `game/rules.py` を参照。
+## Elo 評価（自動グラフ付き）
+
+学習済み (または初期) モデルをランダム/ルールベースと対戦評価:
+
+```powershell
+python -m evaluation.run_eval --episodes 20 --checkpoint checkpoints/policy_value_latest.pt
+```
+
+生成/更新される主ファイル:
+
+| ファイル | 内容 |
+|----------|------|
+| `logs/elo/ratings.json` | 最新 Elo 状態 (player -> rating) |
+| `logs/elo/ratings.csv`  | ゲームごとの全プレイヤー Elo 履歴 |
+| `logs/elo/eval_metrics.csv` | episode 単位の `win_rate, avg_rank, rating_p0` |
+| `logs/elo/figs/eval_progress.png` | WinRate & AvgRank 推移 |
+| `logs/elo/figs/p0_rating.png` | P0 (学習エージェント) Elo 推移 |
+| `logs/elo/figs/elo_history.png` | 全プレイヤー Elo 推移 |
+
+オプション:
+
+```text
+--mix rule,random,random   # ベースライン3枠指定 (rule/random)
+--no-tb                    # TensorBoard 無効
+--no-auto-plot             # 評価終了後の自動PNG生成を無効化
+--num-sim 32               # 評価時 MCTS シミュレーション数上書き
+```
+
+## 手動でプロット再生成のみ行いたい場合
+
+```powershell
+python -m evaluation.plot_eval --elo-dir logs/elo
+```
+
+## 方針 / 実装メモ
+
+- Elo: 4人最終順位を全ペア勝敗に変換し K=32 で Δ を均等適用。
+- 勝率は「1位獲得率」、平均順位は 1(最良)～4(最悪)。
+- 評価メトリクスは逐次 CSV 追記し、再実行で継続。リセットしたい場合は `logs/elo` フォルダを削除。
+
+## 代表クラス / スクリプト
+
+| パス | 役割 |
+|------|------|
+| `agents/drl_agent.py` | AlphaZero 風 MCTS エージェント |
+| `agents/models.py` | PolicyValueNet (方策+価値) |
+| `trainer/trainer.py` | Self-play & train スケジューラ |
+| `evaluation/evaluator.py` | 単発評価ロジック (1ゲーム生成) |
+| `evaluation/rating.py` | Elo 計算 & 永続化 |
+| `evaluation/run_eval.py` | CLI, 自動プロット呼び出し |
+| `evaluation/plot_eval.py` | CSV / Elo 履歴のPNG化 |
+| `game/rules.py` | 革命 / 8切り / 階段 判定など |
+
+## 今後の拡張候補
+
+- K係数スケジューリング (初期高速収束 → 安定化)
+- チェックポイント複数世代の総当たり評価
+- 勝率の信頼区間 (Wilson) 表示
+- 評価時にステップ数や革命頻度の併記
+
+
 

--- a/agents/mcts.py
+++ b/agents/mcts.py
@@ -217,6 +217,19 @@ def run_puct_mcts(root_env_copy,
         g_new.current_field = list(g.current_field)
         g_new.passed = list(g.passed)
         g_new.rankings = list(getattr(g, 'rankings', []))
+        # 重要: rule_checker, deck は共有すると副作用が本番へ伝播するので deepcopy
+        try:
+            g_new.rule_checker = copy.deepcopy(g.rule_checker)
+        except Exception:
+            # 最低限、新しいインスタンスへイベントはコピーしない形でフォールバック
+            from game.rules import RuleChecker
+            rc = RuleChecker()
+            rc.revolution = getattr(g.rule_checker, 'revolution', False)
+            g_new.rule_checker = rc
+        try:
+            g_new.deck = copy.deepcopy(g.deck)
+        except Exception:
+            pass
         env_new = copy.copy(env)
         env_new.game = g_new
         return env_new

--- a/evaluation/evaluator.py
+++ b/evaluation/evaluator.py
@@ -1,0 +1,193 @@
+"""評価用対戦実行モジュール
+
+目的:
+  - 学習済み PolicyValueNet + AlphaZeroAgent を指定 checkpoint から読み込んで評価
+  - ベースライン (RandomAgent / RuleBasedAgent) と 4人対戦を複数エピソード実行
+  - 各エピソードの最終順位を Elo RatingManager に渡してレーティング更新
+  - 評価過程の簡易統計 (勝率, 平均順位) を表示
+
+想定利用:
+  from evaluation.evaluator import Evaluator
+  ev = Evaluator(checkpoint_path="checkpoints/policy_value_latest.pt")
+  ev.run(num_episodes=20)
+
+設計メモ:
+  - 学習コード(trainer)に依存しないよう最小限の import のみ。
+  - AlphaZeroAgent の config は agents.config.ALPHA_ZERO_CONFIG をロードし
+    必要最小限 (デバイス, num_simulations) を override 可。
+  - 評価では探索コストを抑えるため num_simulations を CLI から小さめ指定できるようにする想定。
+"""
+from __future__ import annotations
+
+import os
+import random
+from typing import List, Dict, Any
+
+from agents.models import PolicyValueNet
+from agents.drl_agent import AlphaZeroAgent
+from agents.config import ALPHA_ZERO_CONFIG
+from agents.random_agent import RandomAgent
+from agents.rule_based_agent import RuleBasedAgent
+from game.environment import DaifugoSimpleEnv
+from evaluation.rating import RatingManager, EloConfig
+
+class Evaluator:
+    def __init__(
+        self,
+        checkpoint_path: str = "checkpoints/policy_value_latest.pt",
+        device: str | None = None,
+        num_simulations: int | None = None,
+        elo_dir: str = "logs/elo",
+        seed: int | None = 123,
+        baseline_mix: List[str] | None = None,
+        metrics_csv: str | None = None,
+        use_tensorboard: bool = True,
+    ):
+        if seed is not None:
+            random.seed(seed)
+        self.checkpoint_path = checkpoint_path
+        self.device = device or self._auto_device()
+        self.num_simulations = num_simulations or ALPHA_ZERO_CONFIG.get("num_simulations", 32)
+        self.elo = RatingManager(save_dir=elo_dir, config=EloConfig())
+        # baseline_mix 例: ["rule", "random", "random"] -> 学習エージェント + 3 baseline
+        self.baseline_mix = baseline_mix or ["rule", "random", "random"]
+        self.config = dict(ALPHA_ZERO_CONFIG)
+        self.config["num_simulations"] = self.num_simulations
+        self.config["device"] = self.device
+        # メトリクス CSV 設定
+        self.metrics_csv = metrics_csv or os.path.join(elo_dir, "eval_metrics.csv")
+        os.makedirs(os.path.dirname(self.metrics_csv), exist_ok=True)
+        if not os.path.exists(self.metrics_csv):
+            try:
+                with open(self.metrics_csv, "w", encoding="utf-8") as f:
+                    f.write("episode,win_rate,avg_rank,rating_p0,raw_rank,steps\n")
+            except Exception:
+                pass
+        # TensorBoard (任意)
+        self.tb_writer = None
+        self.use_tensorboard = use_tensorboard
+        if self.use_tensorboard:
+            try:
+                from torch.utils.tensorboard import SummaryWriter  # type: ignore
+                self.tb_writer = SummaryWriter(log_dir=os.path.join(elo_dir, "tb_eval"))
+            except Exception as e:
+                print(f"[WARN] TensorBoard writer init failed: {e}")
+        # モデル読み込み
+        self.model = PolicyValueNet(
+            max_policy_size=self.config["max_policy_size"],
+            hidden_size=self.config["hidden_size"],
+            num_players=self.config["num_players"],
+            device=self.device,
+        )
+        if os.path.exists(self.checkpoint_path):
+            try:
+                self.model.load(self.checkpoint_path)
+            except Exception as e:
+                print(f"[WARN] checkpoint load failed: {e}")
+        else:
+            print(f"[WARN] checkpoint not found: {self.checkpoint_path}. Using random initialized model.")
+        # 評価用 AlphaZeroAgent (player_id=0 固定)
+        self.eval_agent = AlphaZeroAgent(player_id=0, model=self.model, config=self.config)
+
+    def _auto_device(self) -> str:
+        try:
+            import torch
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        except Exception:
+            return "cpu"
+
+    def _make_baseline_agent(self, spec: str, player_id: int):
+        if spec == "rule":
+            return RuleBasedAgent(player_id=player_id)
+        return RandomAgent(player_id=player_id)
+
+    def _build_agents(self) -> List[Any]:
+        agents = [self.eval_agent]
+        # baseline_mix の長さに合わせて 3 名を生成 (足りなければ random で埋める)
+        mix = list(self.baseline_mix)
+        while len(mix) < 3:
+            mix.append("random")
+        for i, spec in enumerate(mix[:3], start=1):
+            agents.append(self._make_baseline_agent(spec, player_id=i))
+        return agents
+
+    def play_one_game(self) -> List[int]:
+        env = DaifugoSimpleEnv(num_players=4, agent_classes=None)
+        # 環境の agents を上書き
+        env.agents = self._build_agents()
+        # 学習エージェントに環境参照 (MCTS 内で利用する可能性)
+        if hasattr(self.eval_agent, 'set_env_ref'):
+            self.eval_agent.set_env_ref(env)
+        # リセット
+        env.reset()
+        # 進行
+        step_limit = 1000
+        steps = 0
+        prev_rankings: List[int] = list(getattr(env.game, 'rankings', []))
+        while not getattr(env.game, 'done', False):
+            if steps >= step_limit:
+                print(f"[WARN] step limit reached ({step_limit}) forcing termination")
+                break
+            current_player_id = env.game.turn
+            agent = env.agents[current_player_id]
+            if isinstance(agent, AlphaZeroAgent):
+                action = agent.select_action(env, training=False)
+            else:
+                # baseline: シンプル観測
+                current_player = env.game.players[current_player_id]
+                hand = current_player.hand
+                field = env.game.current_field[:]
+                legal_actions = env._generate_legal_actions(hand, field)
+                obs_simple = {'hand': hand, 'field': field}
+                action = agent.select_action(obs_simple, legal_actions=legal_actions)
+            try:
+                env.step(external_action=action)
+            except TypeError:
+                env.step(action)
+            steps += 1
+        rankings: List[int] = list(getattr(env.game, 'rankings', []))
+        if len(rankings) != 4:
+            # 強制終了時など順位未確定は残りをランダム末尾扱い
+            remaining = [i for i in range(4) if i not in rankings]
+            rankings += remaining
+        return rankings
+
+    def run(self, num_episodes: int = 10):
+        win_counts = {0: 0}
+        rank_sum = {0: 0}
+        for ep in range(num_episodes):
+            rankings = self.play_one_game()
+            steps = None  # 現在 step カウントは play_one_game 内部で未返却なので拡張余地
+            # Elo 更新 (player 名は pid の文字列化で区別) 順位リストを文字列へ変換
+            ranking_names = [f"P{pid}" for pid in rankings]
+            self.elo.update_from_rankings(ranking_names)
+            # 集計 (評価対象=player0)
+            if rankings[0] == 0:
+                win_counts[0] += 1
+            rank_sum[0] += rankings.index(0) + 1
+            avg_rank = rank_sum[0] / (ep + 1)
+            win_rate = win_counts[0] / (ep + 1)
+            r = self.elo.get_rating("P0")
+            # CSV 追記
+            try:
+                with open(self.metrics_csv, "a", encoding="utf-8") as f:
+                    f.write(f"{ep+1},{win_rate:.6f},{avg_rank:.6f},{r:.2f},{'|'.join(map(str, rankings))},{'' if steps is None else steps}\n")
+            except Exception:
+                pass
+            # TensorBoard 出力
+            if self.tb_writer is not None:
+                self.tb_writer.add_scalar("eval/win_rate", win_rate, ep + 1)
+                self.tb_writer.add_scalar("eval/avg_rank", avg_rank, ep + 1)
+                self.tb_writer.add_scalar("eval/rating_p0", r, ep + 1)
+            if (ep + 1) % 5 == 0 or ep == num_episodes - 1:
+                print(f"[EVAL] ep={ep+1}/{num_episodes} win_rate={win_rate:.2%} avg_rank={avg_rank:.2f} rating(P0)={r:.1f}")
+        # 最終リーダーボード
+        board = self.elo.get_leaderboard()
+        print("[EVAL] Leaderboard (top):")
+        for name, rating in board[:10]:
+            print(f"  {name}: {rating:.1f}")
+        if self.tb_writer is not None:
+            self.tb_writer.flush()
+            self.tb_writer.close()
+
+__all__ = ["Evaluator"]

--- a/evaluation/plot_eval.py
+++ b/evaluation/plot_eval.py
@@ -1,0 +1,126 @@
+"""評価結果可視化スクリプト
+
+eval_metrics.csv (episode,win_rate,avg_rank,rating_p0,raw_rank,steps) と
+ratings.csv (timestamp,game_index,player,rating) を読み取り PNG グラフを出力。
+
+使用例:
+  python -m evaluation.plot_eval --elo-dir logs/elo --out-dir logs/elo/figs
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import csv
+from typing import List, Dict
+
+import matplotlib.pyplot as plt
+
+
+def load_eval_metrics(path: str):
+    episodes = []
+    win_rates = []
+    avg_ranks = []
+    ratings = []
+    if not os.path.exists(path):
+        return episodes, win_rates, avg_ranks, ratings
+    with open(path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                episodes.append(int(row["episode"]))
+                win_rates.append(float(row["win_rate"]))
+                avg_ranks.append(float(row["avg_rank"]))
+                ratings.append(float(row["rating_p0"]))
+            except Exception:
+                continue
+    return episodes, win_rates, avg_ranks, ratings
+
+
+def load_ratings_history(path: str):
+    # returns history[player] = [(game_index, rating_float), ...] sorted
+    history: Dict[str, List[tuple]] = {}
+    if not os.path.exists(path):
+        return history
+    with open(path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                gi = int(row["game_index"])  # 1-based 累積
+                player = row["player"]
+                rating = float(row["rating"])
+                history.setdefault(player, []).append((gi, rating))
+            except Exception:
+                pass
+    for p in history:
+        history[p].sort(key=lambda x: x[0])
+    return history
+
+
+def plot_eval(elo_dir: str, out_dir: str, show: bool = False):
+    os.makedirs(out_dir, exist_ok=True)
+    metrics_csv = os.path.join(elo_dir, "eval_metrics.csv")
+    ratings_csv = os.path.join(elo_dir, "ratings.csv")
+    episodes, win_rates, avg_ranks, ratings = load_eval_metrics(metrics_csv)
+    ratings_hist = load_ratings_history(ratings_csv)
+
+    if episodes:
+        # 勝率と平均順位
+        fig, ax1 = plt.subplots(figsize=(7,4))
+        ax1.plot(episodes, win_rates, label="win_rate", color="tab:blue")
+        ax1.set_ylabel("Win Rate", color="tab:blue")
+        ax1.set_xlabel("Episode")
+        ax1.set_ylim(0, 1.0)
+        ax2 = ax1.twinx()
+        ax2.plot(episodes, avg_ranks, label="avg_rank", color="tab:orange")
+        ax2.set_ylabel("Avg Rank", color="tab:orange")
+        ax2.set_ylim(1, 4)
+        ax1.set_title("Evaluation Progress (P0)")
+        fig.tight_layout()
+        fig.savefig(os.path.join(out_dir, "eval_progress.png"))
+        if show:
+            plt.show()
+        plt.close(fig)
+
+        # レーティング(P0)
+        fig, ax = plt.subplots(figsize=(7,4))
+        ax.plot(episodes, ratings, color="tab:green")
+        ax.set_xlabel("Episode")
+        ax.set_ylabel("Elo Rating (P0)")
+        ax.set_title("P0 Rating Over Episodes")
+        fig.tight_layout()
+        fig.savefig(os.path.join(out_dir, "p0_rating.png"))
+        if show:
+            plt.show()
+        plt.close(fig)
+
+    if ratings_hist:
+        fig, ax = plt.subplots(figsize=(7,4))
+        for player, seq in sorted(ratings_hist.items()):
+            xs = [g for g, _ in seq]
+            ys = [r for _, r in seq]
+            ax.plot(xs, ys, label=player)
+        ax.set_xlabel("Game Index")
+        ax.set_ylabel("Elo Rating")
+        ax.set_title("Elo Ratings History")
+        ax.legend()
+        fig.tight_layout()
+        fig.savefig(os.path.join(out_dir, "elo_history.png"))
+        if show:
+            plt.show()
+        plt.close(fig)
+
+    print(f"[PLOT] generated figures in {out_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="評価結果可視化")
+    parser.add_argument("--elo-dir", type=str, default="logs/elo", help="Elo 保存ディレクトリ")
+    parser.add_argument("--out-dir", type=str, default=None, help="出力先 (省略時 elo-dir/figs)")
+    parser.add_argument("--show", action="store_true", help="matplotlib で表示も行う")
+    args = parser.parse_args()
+    out_dir = args.out_dir or os.path.join(args.elo_dir, "figs")
+    plot_eval(args.elo_dir, out_dir, show=args.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/rating.py
+++ b/evaluation/rating.py
@@ -1,0 +1,151 @@
+"""Elo レーティング計算ユーティリティ
+
+多人数(4人)ゲーム用の簡易 Elo 実装。
+アプローチ:
+ 1. 1ゲーム終了後の最終順位リスト (rankings; index=順位-1, 値=player_id) を入力とする。
+ 2. 全ての (i,j) ペアについて、i の順位 < j の順位 なら i 勝利とみなし 1.0, 逆は 0.0 (同順位は無視: 本ゲームでは発生しない想定)。
+ 3. 各ペアで通常の Elo 期待値 / 更新式を適用し両者のレーティングを更新。
+ 4. 複数ペアを同一ゲーム内で順序依存を減らすため、各プレイヤー毎に Δ を蓄積しゲーム終了後まとめて加算。
+
+式:
+  E_A = 1 / (1 + 10^{(R_B - R_A)/400})
+  ΔA += K * (S_A - E_A)
+
+K-factor は初期デフォルト 32。必要に応じて調整可能。
+
+永続化:
+  RatingManager は ratings.json (player_id -> rating) と ratings.csv (履歴追記: timestamp, game_index, player_id, rating) を扱う。
+
+注意:
+  - 簡易実装のためパフォーマンス最適化は行っていない。
+  - 同時に複数プロセスから書き込む用途は想定していない (排他なし)。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, Iterable
+import json
+import os
+import csv
+import time
+
+
+@dataclass
+class EloConfig:
+    initial_rating: float = 1000.0
+    k_factor: float = 32.0
+    min_rating: float = 0.0  # クリッピング下限 (負値増幅防止)
+
+
+@dataclass
+class RatingManager:
+    save_dir: str = "logs/elo"
+    config: EloConfig = field(default_factory=EloConfig)
+    ratings: Dict[str, float] = field(default_factory=dict)  # key: player_name
+    game_index: int = 0  # 永続化された最後のゲーム番号 (CSV の行数ではない)
+
+    def __post_init__(self):
+        os.makedirs(self.save_dir, exist_ok=True)
+        self._ratings_path = os.path.join(self.save_dir, "ratings.json")
+        self._history_path = os.path.join(self.save_dir, "ratings.csv")
+        self._load_if_exists()
+
+    # ----------------------------
+    # 永続化
+    # ----------------------------
+    def _load_if_exists(self):
+        if os.path.exists(self._ratings_path):
+            try:
+                with open(self._ratings_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                # game_index を含む形式 {"ratings": {...}, "game_index": N} を期待
+                if isinstance(data, dict) and "ratings" in data:
+                    self.ratings = {k: float(v) for k, v in data.get("ratings", {}).items()}
+                    self.game_index = int(data.get("game_index", 0))
+                else:
+                    # 後方互換: 旧形式 (player_id -> rating)
+                    self.ratings = {k: float(v) for k, v in data.items()}
+            except Exception:
+                pass
+        # 履歴CSVがなければヘッダを書く
+        if not os.path.exists(self._history_path):
+            with open(self._history_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(["timestamp", "game_index", "player", "rating"])
+
+    def _save(self):
+        data = {
+            "ratings": self.ratings,
+            "game_index": self.game_index,
+        }
+        with open(self._ratings_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+
+    def _append_history(self):
+        ts = int(time.time())
+        with open(self._history_path, "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            for player, rating in self.ratings.items():
+                writer.writerow([ts, self.game_index, player, f"{rating:.2f}"])
+
+    # ----------------------------
+    # 公開 API
+    # ----------------------------
+    def ensure_player(self, player: str):
+        if player not in self.ratings:
+            self.ratings[player] = self.config.initial_rating
+
+    def ensure_players(self, players: Iterable[str]):
+        for p in players:
+            self.ensure_player(p)
+
+    def get_rating(self, player: str) -> float:
+        return self.ratings.get(player, self.config.initial_rating)
+
+    def expected_score(self, ra: float, rb: float) -> float:
+        return 1.0 / (1.0 + 10 ** ((rb - ra) / 400.0))
+
+    def update_from_rankings(self, rankings: List[str]):
+        """最終順位 (先頭=1位) のプレイヤー名リストからレーティングを更新。
+        重複しない前提。本ゲームで同着は起こらない前提。
+        """
+        # 未登録プレイヤー初期化
+        self.ensure_players(rankings)
+        # プレイヤーごとの Δ 累積
+        delta: Dict[str, float] = {p: 0.0 for p in rankings}
+        k = self.config.k_factor
+        n = len(rankings)
+        # ペアワイズ比較 O(n^2)
+        for i in range(n):
+            for j in range(i + 1, n):
+                winner = rankings[i]
+                loser = rankings[j]
+                ra = self.ratings[winner]
+                rb = self.ratings[loser]
+                ea = self.expected_score(ra, rb)
+                eb = self.expected_score(rb, ra)
+                # 勝者視点 S=1, 敗者視点 S=0
+                delta[winner] += k * (1.0 - ea)
+                delta[loser] += k * (0.0 - eb)
+        # 一括適用
+        for p, d in delta.items():
+            new_r = self.ratings[p] + d
+            if new_r < self.config.min_rating:
+                new_r = self.config.min_rating
+            self.ratings[p] = new_r
+        # ゲームインデックス更新 & 保存
+        self.game_index += 1
+        self._save()
+        self._append_history()
+
+    def batch_update(self, list_of_rankings: List[List[str]]):
+        for r in list_of_rankings:
+            self.update_from_rankings(r)
+
+    def get_leaderboard(self) -> List[Tuple[str, float]]:
+        return sorted(self.ratings.items(), key=lambda x: x[1], reverse=True)
+
+    def as_dict(self) -> Dict[str, float]:
+        return dict(self.ratings)
+
+__all__ = ["EloConfig", "RatingManager"]

--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -1,0 +1,50 @@
+"""Elo 評価 CLI
+
+実行例:
+  python -m evaluation.run_eval --episodes 20 --checkpoint checkpoints/policy_value_latest.pt --num-sim 32
+"""
+from __future__ import annotations
+
+import argparse
+
+from evaluation.evaluator import Evaluator
+from evaluation.plot_eval import plot_eval
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Daifugo AlphaZero 評価 (Elo)")
+    parser.add_argument("--episodes", type=int, default=10, help="評価エピソード数")
+    parser.add_argument("--checkpoint", type=str, default="checkpoints/policy_value_latest.pt", help="評価するモデルのチェックポイントパス")
+    parser.add_argument("--device", type=str, default=None, help="使用デバイス (cpu/cuda). 省略時は自動")
+    parser.add_argument("--num-sim", type=int, default=None, help="MCTS シミュレーション数 (デフォルトは config 既定値)")
+    parser.add_argument("--elo-dir", type=str, default="logs/elo", help="Elo レーティング保存ディレクトリ")
+    parser.add_argument("--mix", type=str, default="rule,random,random", help="ベースライン3枠の種類をカンマ区切り (rule / random)")
+    parser.add_argument("--no-tb", action="store_true", help="TensorBoard 出力を無効化")
+    parser.add_argument("--metrics-csv", type=str, default=None, help="評価メトリクスCSV(指定で上書き)")
+    parser.add_argument("--no-auto-plot", action="store_true", help="評価後に自動でグラフ更新を行わない")
+    parser.add_argument("--seed", type=int, default=123, help="乱数シード")
+    args = parser.parse_args()
+
+    baseline_mix = [m.strip() for m in args.mix.split(',') if m.strip()]
+
+    evaluator = Evaluator(
+        checkpoint_path=args.checkpoint,
+        device=args.device,
+        num_simulations=args.num_sim,
+        elo_dir=args.elo_dir,
+        seed=args.seed,
+        baseline_mix=baseline_mix,
+        metrics_csv=args.metrics_csv,
+        use_tensorboard=not args.no_tb,
+    )
+    evaluator.run(num_episodes=args.episodes)
+    if not args.no_auto_plot:
+        # 自動プロット更新 (figs ディレクトリを明示)
+        out_dir = os.path.join(args.elo_dir, "figs")
+        plot_eval(args.elo_dir, out_dir, show=False)
+        print(f"[EVAL] plots updated -> {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/game/game.py
+++ b/game/game.py
@@ -181,8 +181,11 @@ class Game:
                 pass
             new_rev = self.rule_checker.revolution
             rev_changed = (prev_rev != new_rev)
+            # トグル仕様: 変化したら [+REV] / [-REV]
             rev_flag = ' (REV)' if new_rev else ''
-            trig = ' [+REV]' if rev_changed and new_rev else (' [-REV]' if rev_changed and not new_rev else '')
+            trig = ''
+            if rev_changed:
+                trig = ' [+REV]' if new_rev else ' [-REV]'
             # 3) プレイログ (リセット系より先に必ず出す)
             self.log(f"Player {self.turn} played: {played_str}{rev_flag}{trig}")
             # 革命発生メッセージ (オプション) - 従来互換

--- a/game/rules.py
+++ b/game/rules.py
@@ -291,73 +291,69 @@ class RuleChecker:
 
     def check_revolution(self, cards, player_id=None, turn_count=None):
         """
-        革命発生条件を判定し、該当すればself.revolutionをTrueにする。
-        例: 同じランク4枚以上（ジョーカー含む場合は調整可）、または5枚以上の階段
+        革命トグル判定 (現在の仕様):
+          - 条件: (1) 四枚同ランク(ジョーカー補完可, ちょうど4枚) または (2) 5枚以上の階段(ジョーカー可)
+          - 条件成立ごとに revolution フラグを反転 (OFF→ON / ON→OFF)
+          - 同一手番・同一カード集合での多重トグル防止 (idempotent)
+        戻り値: トグルが発生した場合 True, それ以外 False
         """
-        # 同一手番・同一カード集合に対する重複判定（安全側: 情報が無ければスキップ）
+        if not cards:
+            return False
+        # 重複発火保護キー
         action_key = None
         try:
-            if turn_count is not None and player_id is not None and cards is not None:
+            if turn_count is not None and player_id is not None:
                 canonical_cards = tuple(sorted(str(c) for c in cards))
                 action_key = (int(turn_count), int(player_id), canonical_cards)
                 if action_key in self._rev_seen_actions:
                     return False
         except Exception:
-            # 何らかの理由でキー生成失敗時は保護を無効化して継続
             action_key = None
+
         non_jokers = [c for c in cards if not c.is_joker]
         jokers = [c for c in cards if c.is_joker]
-        old_state = self.revolution
-        toggled = False
-        reason = None
-        meta = {
-            'straight_len': None,
-            'rank': None,
-            'jokers': len(jokers),
-        }
-        # 4枚(以上)同ランク条件
-        if self.rev_enable_four_kind and len(non_jokers) > 0:
-            rank = non_jokers[0].rank
-            same_rank_with_jokers = all(c.rank == rank or c.is_joker for c in cards)
-            size_ok = (
-                (len(cards) == 4 if self.rev_four_kind_exact else len(cards) >= 4)
-            )
-            jokers_used = len(jokers) > 0
-            pure = same_rank_with_jokers and not jokers_used
-            cond_joker = self.rev_four_kind_allow_joker or not jokers_used
-            if not toggled and size_ok and same_rank_with_jokers and cond_joker:
-                self.revolution = not self.revolution
-                toggled = True
-                reason = 'four_kind'
-                meta['rank'] = rank
-                meta['pure'] = pure
-        # 階段条件
-        if (self.rev_enable_straight and not toggled and len(cards) >= self.rev_straight_min_len):
+
+        # 条件1: 四枚同ランク (ジョーカーで補完してよい) - ちょうど4枚
+        four_kind_ok = False
+        if len(cards) == 4:
+            if len(non_jokers) > 0:
+                base_rank = non_jokers[0].rank
+                if all(c.rank == base_rank or c.is_joker for c in cards):
+                    four_kind_ok = True
+
+        # 条件2: 5枚以上の階段 (ジョーカー使用可) - is_straight 判定利用
+        straight_ok = False
+        if len(cards) >= 5:
             if self.is_straight(cards):
-                jokers_used = len(jokers) > 0
-                if self.rev_straight_allow_joker or not jokers_used:
-                    self.revolution = not self.revolution
-                    toggled = True
-                    reason = 'long_straight'
-                    meta['straight_len'] = len(cards)
-                    meta['used_joker'] = jokers_used
-        if toggled:
-            event = {
-                'turn': turn_count,
-                'player': player_id,
-                'reason': reason,
-                'cards': [str(c) for c in cards],
-                'old_state': old_state,
-                'new_state': self.revolution,
-                'size': len(cards),
-                'meta': meta,
-            }
-            self.revolution_events.append(event)
-            # このアクションに対するトグルは記録済みとしてマーク（再トグル抑止）
-            if action_key is not None:
-                self._rev_seen_actions.add(action_key)
-            return True
-        return False
+                straight_ok = True
+
+        if not (four_kind_ok or straight_ok):
+            return False
+
+        # トグル
+        old_state = self.revolution
+        self.revolution = not self.revolution
+        pure = (len(jokers) == 0)
+        event = {
+            'turn': turn_count,
+            'player': player_id,
+            'reason': 'four_kind' if four_kind_ok else 'long_straight',
+            'cards': [str(c) for c in cards],
+            'old_state': old_state,
+            'new_state': self.revolution,
+            'size': len(cards),
+            'meta': {
+                'straight_len': len(cards) if straight_ok else None,
+                'rank': non_jokers[0].rank if four_kind_ok else None,
+                'jokers': len(jokers),
+                'pure': pure,
+                'toggled': True,
+            },
+        }
+        self.revolution_events.append(event)
+        if action_key is not None:
+            self._rev_seen_actions.add(action_key)
+        return True
 
     def reset_revolution(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ tensorboard==2.16.2
 
 # TensorBoard compatibility (avoid MessageToJson keyword error)
 protobuf==4.25.3
+
+# Plotting (evaluation visualization)
+matplotlib==3.9.0


### PR DESCRIPTION
This pull request introduces a comprehensive Elo-based evaluation and visualization pipeline for the Daifugo (大富豪) reinforcement learning environment, enabling automated model assessment and performance tracking. It adds modules for Elo rating calculation, multi-agent evaluation, and plotting of results, along with major documentation updates. The changes are grouped below by theme.

**Evaluation & Elo Rating System**

* Added `evaluation/evaluator.py`: Implements the `Evaluator` class for running multi-agent evaluation episodes, updating Elo ratings, saving metrics, and supporting baseline agent mixes and TensorBoard logging.
* Added `evaluation/rating.py`: Provides an Elo rating utility for multi-player games, including rating persistence, pairwise updates based on rankings, and leaderboard generation.

**Visualization & CLI Tools**

* Added `evaluation/plot_eval.py`: Reads evaluation metrics and Elo history CSVs to generate PNG plots of win rate, average rank, and Elo rating progression for all players.
* Added `evaluation/run_eval.py`: CLI script for running evaluations, configuring agent mixes, and automatically updating performance plots after evaluation.

**Documentation & Usability**

* Major rewrite of `README.md`: Clearly describes the new evaluation workflow, directory structure, key features, representative scripts/classes, and extensibility options for Elo evaluation and visualization.

**Bugfixes / Reliability**

* Improved environment cloning in `agents/mcts.py`: Ensures deep copies of `rule_checker` and `deck` to avoid unintended side effects during MCTS simulations.<!-- このプルリクエストの内容を日本語で記載してください。 -->
## 概要

## 変更内容

## 動作確認

## その他